### PR TITLE
Bench `convert` & iterative `extended_gcd`

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -2,6 +2,7 @@ use criterion::measurement::WallTime;
 use criterion::BenchmarkGroup;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
+use rns_rs::convert::{from_rns, to_rns};
 use rns_rs::modulus::find_suitable_modulus;
 
 fn bench_find_suitable_modulus(c: &mut Criterion) {
@@ -20,5 +21,48 @@ fn do_bench_find_suitable_modulus(c: &mut BenchmarkGroup<WallTime>, num: u64) {
     });
 }
 
-criterion_group!(modulus, bench_find_suitable_modulus);
+fn bench_to_rns(c: &mut Criterion) {
+    let mut group = c.benchmark_group("to_rns".to_string());
+    group.sample_size(10);
+
+    do_bench_to_rns(&mut group, 32);
+    do_bench_to_rns(&mut group, 15386);
+    do_bench_to_rns(&mut group, 163879197);
+    do_bench_to_rns(&mut group, 360287981029);
+}
+
+fn do_bench_to_rns(c: &mut BenchmarkGroup<WallTime>, num: u64) {
+    c.bench_function(format!("to_rns({num})"), |b| {
+        b.iter(|| black_box(to_rns(num)))
+    });
+}
+
+fn bench_from_rns(c: &mut Criterion) {
+    let mut group = c.benchmark_group("from_rns".to_string());
+    group.sample_size(10);
+
+    do_bench_from_rns(
+        &mut group,
+        &[2, 0, 2, 6, 8, 2, 3, 9, 12, 9, 5, 39, 12, 18, 18, 44, 59, 42],
+    );
+    do_bench_from_rns(
+        &mut group,
+        &[
+            2, 0, 5, 1, 11, 2, 10, 5, 15, 23, 15, 29, 19, 1, 15, 34, 24, 14,
+        ],
+    );
+}
+
+fn do_bench_from_rns(c: &mut BenchmarkGroup<WallTime>, num: &[u8]) {
+    c.bench_function(format!("from_rns({num:?})"), |b| {
+        b.iter(|| black_box(from_rns(num)))
+    });
+}
+
+criterion_group!(
+    modulus,
+    bench_find_suitable_modulus,
+    bench_to_rns,
+    bench_from_rns
+);
 criterion_main!(modulus);

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,4 +1,6 @@
-const PRIME_BASE_U64: [u64; 18] = [3,5,7,11,13,17,19,23,29,31,37,41,43,47,53,59,61,67];
+const PRIME_BASE_U64: [u64; 18] = [
+    3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67,
+];
 
 pub fn to_rns(x: u64) -> Vec<u8> {
     PRIME_BASE_U64.iter().map(|&m| (x % m) as u8).collect()
@@ -11,10 +13,12 @@ pub fn from_rns(remainders: &[u8]) -> u64 {
 
     for (&r_i, &m_i) in remainders.iter().zip(PRIME_BASE_U64.iter()) {
         let m_i_ = m_acc; // Текущее произведение предыдущих модулей
-        // println!("M_i = {}, m_i = {}, extended_gcd = {:?}", m_i_, m_i, extended_gcd(m_i_ as i64, m_i as i64));
+                          // println!("M_i = {}, m_i = {}, extended_gcd = {:?}", m_i_, m_i, extended_gcd(m_i_ as i64, m_i as i64));
 
-        let m_i_inv = mod_inverse(m_i_ as i64, m_i as i64)
-            .expect(&format!("Обратный элемент не существует для {} mod {}", m_i_, m_i)) as u128;
+        let m_i_inv = mod_inverse(m_i_ as i64, m_i as i64).expect(&format!(
+            "Обратный элемент не существует для {} mod {}",
+            m_i_, m_i
+        )) as u128;
 
         // Безопасное вычисление разницы (гарантированно неотрицательное значение)
         let delta = (r_i as u128 + m_i as u128 - (result % m_i as u128)) % m_i as u128;
@@ -30,13 +34,22 @@ pub fn from_rns(remainders: &[u8]) -> u64 {
 /// Функция нахождения обратного элемента (mod_inverse)
 fn mod_inverse(a: i64, m: i64) -> Option<i64> {
     let (g, x, _) = extended_gcd(a, m);
-    if g != 1 { return None; } // Если НОД не 1, обратного элемента нет
+    if g != 1 {
+        return None;
+    } // Если НОД не 1, обратного элемента нет
     Some((x % m + m) % m)
 }
 
 /// Расширенный алгоритм Евклида
-fn extended_gcd(a: i64, b: i64) -> (i64, i64, i64) {
-    if a == 0 { return (b, 0, 1); }
-    let (g, x1, y1) = extended_gcd(b % a, a);
-    (g, y1 - (b / a) * x1, x1)
+fn extended_gcd(mut a: i64, mut b: i64) -> (i64, i64, i64) {
+    let (mut old_s, mut s, mut old_t, mut t) = (1, 0, 0, 1);
+
+    while a != 0 {
+        let q = b / a;
+        (b, a) = (a, b % a);
+        (old_s, s) = (s, old_s - q * s);
+        (old_t, t) = (t, old_t - q * t);
+    }
+
+    (b, old_t, old_s)
 }


### PR DESCRIPTION
Using the iterative version of `extended_gcd` improved performance on the proposed benchmarks:

```
Benchmarking from_rns/from_rns([2, 0, 2, 6, 8, 2, 3, 9, 12, 9, 5, 39, 12, 18, 18, 44, 59, 42]): Collecting 10 samples in estimatfrom_rns/from_rns([2, 0, 2, 6, 8, 2, 3, 9, 12, 9, 5, 39, 12, 18, 18, 44, 59, 42])
                        time:   [929.03 ns 932.87 ns 936.43 ns]
                        change: [-8.1243% -7.7533% -7.3789%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking from_rns/from_rns([2, 0, 5, 1, 11, 2, 10, 5, 15, 23, 15, 29, 19, 1, 15, 34, 24, 14]): Collecting 10 samples in estifrom_rns/from_rns([2, 0, 5, 1, 11, 2, 10, 5, 15, 23, 15, 29, 19, 1, 15, 34, 24, 14])
                        time:   [897.64 ns 899.62 ns 901.13 ns]
                        change: [-11.321% -10.945% -10.529%] (p = 0.00 < 0.05)
                        Performance has improved.
```